### PR TITLE
Ps 1573 nested updates

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -158,7 +158,7 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
             id_value = match.kwargs[lookup_field_name]
 
         # getting the actual instance. TODO: this is to be merged with outer code
-        instance = model_class.objects.filter(lookup_field_name=id_value).first()
+        instance = model_class.objects.filter(**{lookup_field_name: id_value}).first()
         if instance:
             return str(instance.pk)
 

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -162,7 +162,6 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
         if instance:
             return str(instance.pk)
 
-
     def update_or_create_reverse_relations(self, instance, reverse_relations):
         # Update or create reverse relations:
         # many-to-one, many-to-many, reversed one-to-one
@@ -194,7 +193,7 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
             new_related_instances = []
             for data in related_data:
                 obj = instances.get(
-                    self._get_related_pk(data, field.Meta.model, related_field=related_field)
+                    self._get_related_pk(data, field.Meta.model, related_field=field)
                 )
                 serializer = self._get_serializer_for_field(
                     field,

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -94,7 +94,7 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
         model_class = field.Meta.model
         pk_list = []
         for d in filter(None, related_data):
-            pk = self._get_related_pk(d, model_class)
+            pk = self._get_related_pk(d, model_class, related_field=field)
             if pk:
                 pk_list.append(pk)
 


### PR DESCRIPTION
- updates of nested resources now supported
- no need to supply the whole nested resource in order to connect it to parent, id is suffice
- it supports URLs (HyperlinkIndentityField), UUIDs, pk and ids as identifiers of resource, so the instances can be addressed by either of these fields, no need to expose `pk` anymore in our API
- support of M2M fields added

Unit tests are not added though considering tight deadlines for that feature. Test cases descriptions are prepared in the ticket comments.  